### PR TITLE
fixed deprecated version of jQuery.error and jQuery.load that prevent the library to work with jQuery3

### DIFF
--- a/src/jquery.skitter.js
+++ b/src/jquery.skitter.js
@@ -634,13 +634,13 @@
         var src = self.getImageName(self_il[0]);
         var img = new Image();
         
-        $(img).load(function () {
+        $(img).load('load', function () {
           ++u;
           if (u == total) {
             self.skitter_box.find('.skitter-spinner').remove();
             self.start();
           }
-        }).error(function () {
+        }).on('error', function () {
           self.skitter_box.find('.skitter-spinner, .image_number, .next_button, .prev_button').remove();
           self.skitter_box.html('<p style="color:white;background:black;">Error loading images. One or more images were not found.</p>');
         }).attr('src', src);


### PR DESCRIPTION
Hey Thiago, 

first thanks for your library, it's great!

i've tried the examples provided (in the /examples folder) with jquery 2.1 and it works great but as soon as i change the version to jquery  3.0 i kept getting this error on console.

> jQuery 3: error 'url.indexOf is not a function' 

it looks like few methods of jQuery has changed during the major upgrade to v.3 in particular the jQuery.fn.load and jQuery.fn.error that you're using on jquery.skitter.js on line **637** and **643**.

i've only updated these two lines of code with the correspondent newer versions.

jQuery.fn.load must have the first parameter url set (in version < 3 was optional)
and jQuery.fn.error became jQuery.fn.on

With this minor fixes it seems to work properly for jQuery v3 and prior versions.

i've tested the changes on your examples folder, with jquery 3.2.1 (latest stable version).

**jquery.skitter.js**

![image](https://cloud.githubusercontent.com/assets/4570071/26556985/51c2b740-449e-11e7-8fc2-7c51f9fef7a0.png)
