### PR TITLE
changed load() with on()

### DIFF
--- a/src/jquery.skitter.js
+++ b/src/jquery.skitter.js
@@ -634,7 +634,7 @@
         var src = self.getImageName(self_il[0]);
         var img = new Image();
         
-        $(img).load('load', function () {
+        $(img).on('load', function () {
           ++u;
           if (u == total) {
             self.skitter_box.find('.skitter-spinner').remove();


### PR DESCRIPTION
Sorry thiago for opening a new pr.

last commit i use jQuery.fn.load('url', fn)

it was working fine but giving some warning on the console , i looked over the documentation and find out that i should be using jQuery.fn.on() even in case of success.

just changed one line of code.

now your examples works with no errors and no warnings.

sorry for the double pr and thx again for the library :+1:  :100: 

![image](https://cloud.githubusercontent.com/assets/4570071/26585312/043c5c7a-454c-11e7-813a-cb8b513977f6.png)

<a href="https://blog.jquery.com/2015/07/13/jquery-3-0-and-jquery-compat-3-0-alpha-versions-released/">jQuery Doc</a>

